### PR TITLE
Fix server import order and audit script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your-openai-key-here

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ Generated on 2025-06-21T12:45:23
 docker compose up --build
 ```
 
+Create a `.env` file with your OpenAI credentials before running Docker:
+
+```bash
+cp .env.example .env
+echo OPENAI_API_KEY=your-key >> .env
+```
+
 ### Endpoints
 | Path | Function |
 |------|----------|

--- a/app/server.py
+++ b/app/server.py
@@ -2,14 +2,15 @@
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
+import uvicorn
+
+api = FastAPI(title="Synthetic Soul Assistant")
+
 from .metrics_exporter import router as metrics_router
 api.include_router(metrics_router)
 
-import uvicorn
 from .workspace import app as workspace_app
 from .magic_rect import magic_rect
-
-api=FastAPI(title="Synthetic Soul Assistant")
 
 class ChatRequest(BaseModel):
     text:str

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     build: .
     environment:
       - LANGCHAIN_TRACING_V2=true
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
     ports:
       - "8000:8000"
     volumes:

--- a/maintenance/memory_diff_audit.py
+++ b/maintenance/memory_diff_audit.py
@@ -35,8 +35,12 @@ def main():
         new_items = diff(prev_fp, json.loads(fp.read_text()))
         if new_items:
             from app.metrics_exporter import memory_violations
-        memory_violations.inc(len(new_items))
-        logging.warning("Detected %d untracked memories: %s", len(new_items), new_items[:5])
+            memory_violations.inc(len(new_items))
+            logging.warning(
+                "Detected %d untracked memories: %s",
+                len(new_items),
+                new_items[:5],
+            )
         else:
             logging.info("No untracked memories detected.")
     logging.info("Memory diff audit complete – digest %s", digest)


### PR DESCRIPTION
## Summary
- reorder imports in `app/server.py` so router can be attached
- fix indentation in `maintenance/memory_diff_audit.py`
- document providing `OPENAI_API_KEY` via `.env` file
- expose the OpenAI key in `docker-compose.yml`
- add `.env.example` template

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856e34ae28883259ae7db0c74892e87