### PR TITLE
Fix missing langchain module error and update tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 
 langchain
+langchain-community
 langgraph
 memgpt
 chromadb

--- a/tests/test_magic_rect.py
+++ b/tests/test_magic_rect.py
@@ -1,4 +1,7 @@
 
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from app.magic_rect import magic_rect
 
 def test_claim_release():


### PR DESCRIPTION
## Summary
- add `langchain-community` to the dependencies
- adjust test to make sure `app` package is discoverable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856edb6ef64832599231463227dbc44